### PR TITLE
Error codes - Fix to return 1 (error) when assembly fails

### DIFF
--- a/Source/Main.c
+++ b/Source/Main.c
@@ -123,6 +123,10 @@ int main(int argc, char *argv[])
     /* End of error handling */
     my_RaiseError(ERROR_END,NULL);
 
+
+    if (error) {
+      return EXIT_FAILURE;
+    }
     /* OK */
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This changes the exit code to EXIT_FAILURE when the assembly failed.  Previously, it would exit with EXIT_SUCCESS on anything as long as it got to the assembly step, so it would only fail if you tried to pass in a non-existent file, for example.  

I have tested this change and still get 0 (success) on anything that generates a binary and am now correctly getting 1 (fail) when the assembly fails.  

I do not know of any conditions where there are errors that we could safely ignore, but if that's the case then they simply need to avoid incrementing the `nb_error` value inside of the various a65816_Line.c routines. 
