### PR TITLE
Fix TYP direxctive

### DIFF
--- a/Source/Main.c
+++ b/Source/Main.c
@@ -123,6 +123,10 @@ int main(int argc, char *argv[])
     /* End of error handling */
     my_RaiseError(ERROR_END,NULL);
 
+
+    if (error) {
+      return EXIT_FAILURE;
+    }
     /* OK */
     return EXIT_SUCCESS;
 }

--- a/Source/a65816_Line.c
+++ b/Source/a65816_Line.c
@@ -188,7 +188,17 @@ int DecodeLineType(struct source_line *first_line, struct macro *current_macro, 
                 AddDateLine(current_line);
             continue;
         }
-        
+
+         /** TYP: File type **/
+        if(!my_stricmp(current_line->opcode_txt,"TYP"))
+        {
+            current_line->type = LINE_DIRECTIVE;
+
+            /* Decode the value */
+            current_omfproject->type = GetByteValue(current_line->operand_txt);
+            continue;
+        }
+
         /** Line Defining a Global Entry Point for InterSegs **/
         if(strlen(current_line->label_txt) > 0 && !my_stricmp(current_line->opcode_txt,"ENT"))
         {


### PR DESCRIPTION
This PR changes Merlin32 behavior to match original Merlin16+ behavior on 'TYP'.

Previously Merlin32 ignored the `TYP` directive except in link files, so if you were trying to assemble a single `.s` file and use `DSK` and `TYP` to create an output system file, it would create the file but set the filetype in _FileInformation.txt to $00.  Even if you set it correctly, it would overwrite it, so I got tired of it and fixed this.  
