### PR TITLE
Fix Bug where OMF entries would be generated for constant data

### DIFF
--- a/Source/Dc_Library.c
+++ b/Source/Dc_Library.c
@@ -4415,7 +4415,10 @@ int64_t EvalExpressionAsInteger(char *expression_param, char *buffer_error_rtn, 
         *offset_reference_rtn = (WORD) value_expression;
     }
     else
+	{
+        *is_reloc_rtn = 0;  /* BuildOneLineData depends on this being set, perhaps other things do too */
         *expression_address_rtn = (0x00FFFFFF & value_expression);   /* Adresse Longue 24 bit : Bank/HighLow */
+	}
     
     /** We modify the value returned according to the Prefix #><^| **/
     if((has_hash == 1 || is_pea_opcode == 1 || current_line->type == LINE_DATA) && has_more == 1)

--- a/Source/version.h
+++ b/Source/version.h
@@ -1,3 +1,3 @@
 #ifndef MERLIN_VERSION
-#define MERLIN_VERSION "v1.1.9"
+#define MERLIN_VERSION "v1.1.10"
 #endif


### PR DESCRIPTION
Fix for reported bug where extra OMF entries would be created for constant data.  EvalExpressionAsInteger was not returning false for is_reloc_rtn, when the is_reloc_rtn should be set to false.


 