### PR TITLE
Macos universal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Create Release Job
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
     - name: Download Release Data
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v1
       with:
         name: data
     - name: Get Tag Name
@@ -53,7 +53,7 @@ jobs:
         echo ::set-output name=RELEASE_URL::$URL
         echo "URL = $URL"
         echo name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v1
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Make Nix
       if: matrix.os != 'windows-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
     - name: Download Release Data
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
         name: data
     - name: Get Tag Name
@@ -53,7 +53,7 @@ jobs:
         echo ::set-output name=RELEASE_URL::$URL
         echo "URL = $URL"
         echo name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Make Nix
       if: matrix.os != 'windows-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,10 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
     - name: Download Release Data
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
         name: data
+        path: data
     - name: Get Tag Name
       id: get_data
       shell: bash
@@ -53,7 +54,7 @@ jobs:
         echo ::set-output name=RELEASE_URL::$URL
         echo "URL = $URL"
         echo name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Make Nix
       if: matrix.os != 'windows-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Create Release Job
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v1
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1.0.0

--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -32,6 +32,9 @@ else
 
     ifdef CPU_OPT
         ifeq ($(OS),Darwin)
+            # add both mac architectures to create a fat universal binary
+            CFLAGS+=-arch x86_64 
+            CFLAGS+=-arch arm64
             MAH_SHEEN:=$(shell machine)
             ifeq ($(CPU),powerpc)
                 CFLAGS+=-fast

--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -29,12 +29,14 @@ else
     
     OS:=$(shell uname -s)
     CPU:=$(shell uname -p)
-
+    ifeq ($(OS),Darwin)
+        # add both mac architectures to create a fat universal binary
+        CFLAGS+=-arch x86_64 
+        CFLAGS+=-arch arm64
+    endif
+    
     ifdef CPU_OPT
         ifeq ($(OS),Darwin)
-            # add both mac architectures to create a fat universal binary
-            CFLAGS+=-arch x86_64 
-            CFLAGS+=-arch arm64
             MAH_SHEEN:=$(shell machine)
             ifeq ($(CPU),powerpc)
                 CFLAGS+=-fast


### PR DESCRIPTION
I verified this seems to work for creating a universal binary:

```
❯ file merlin32
merlin32: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64Mach-O 64-bit executable x86_64] [arm64:Mach-O 64-bit executable arm64Mach-O 64-bit executable arm64]
merlin32 (for architecture x86_64):	Mach-O 64-bit executable x86_64
merlin32 (for architecture arm64):	Mach-O 64-bit executable arm64
```